### PR TITLE
Fix office results containing alternates

### DIFF
--- a/posuto/prep.py
+++ b/posuto/prep.py
@@ -122,12 +122,13 @@ def build_office_json(fname):
             info['prefecture_kana'] = readings[0]
             info['city_kana'] = readings[1]
             info['neighborhood_kana'] = readings[2]
+            # Ensure alternates is set to avoid issues with instantiating the OfficeCodeBase named tuple.
+            info.setdefault('alternates', [])
 
             code = info['postal_code']
             if code in data:
                 data[code]['alternates'].append(info)
             else:
-                info['alternates'] = []
                 data[code] = info
 
     # write json file

--- a/posuto/tests/test_basic.py
+++ b/posuto/tests/test_basic.py
@@ -13,6 +13,12 @@ def test_mitsukoujimachi():
     # This may be unstable with time
     assert info.alternates[0].neighborhood == '三小牛町'
 
+def test_office_alternate_without_alternate():
+    # This used to be an error because an alternate did not itself contain alternates:
+    # <lambda>() missing 1 required positional argument: 'alternates'
+    info = posuto.get('2248524')
+    assert info.alternates[0].alternates == []
+
 def test_portcity():
     # see #8, this was also a romaji related error
     info = posuto.get("1057529")

--- a/posuto/tests/test_basic.py
+++ b/posuto/tests/test_basic.py
@@ -37,11 +37,11 @@ def test_contextmanager():
         assert tower.kana == 'トウキョウトミナトクシバコウエン', "Address kana is wrong"
         assert tower.note == None, "Address note is wrong"
 
-def test_office():
+def test_office_code():
     info = posuto.get('8690198')
     assert info.name == '長洲町役場', "Address is wrong"
 
-def test_office():
+def test_office_kana():
     info = posuto.get('0608703')
     assert info.neighborhood_kana == "キタ１ジョウニシ", "Office kana are wrong"
 


### PR DESCRIPTION
I encountered an issue getting office results for code `2248524`. The problem was unlike `postaldata.json`, alternates in `officedata.json` were missing the `alternates` field. This resulted in the following error [when instantiating OfficeCodeBase](https://github.com/polm/posuto/blob/master/posuto/posuto.py#L85) for each alternate:  
> TypeError("<lambda>() missing 1 required positional argument: 'alternates'")

My original approach was to modify the results at run time, but in the end I went with modifying prep.py to always include alternates and updated the office data. Let me know if you prefer another approach.

Also [renamed a test](https://github.com/polm/posuto/commit/178c168fa8a9237675898cf027570a60dbe60389) that was shadowing another one with the same name.